### PR TITLE
Fix keybinding typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ paste-and-indent was the superior extension, so I decided to solve the small pro
 
 Provides a command palette item named paste-indent that will paste text following the indentation of the current line. The pasted block is left justified within the indentation.
 
-There are no keybindings set, but you can set them yourself. I suggest mapping "cmd+shift+v" to the paste-indent command.
+There are no keybindings set, but you can set them yourself. I suggest mapping "ctrl+cmd+v" to the paste-indent command.
 On macOs, I have ~/Library/Application Support/Code/User/keybindings.json
 ```
     {


### PR DESCRIPTION
Line 23 of readme suggests mapping "cmd+shift+v", but both the keybindings.json snippet and the Keyboard Shortcuts Settings instructions use "ctrl+cmd+v" instead, which could confuse new users. I guess the typo happened because you suggested mapping "cmd+shift+v" at first, then separately added the keybinding instructions at a later date in v0.0.4.